### PR TITLE
Remove top rule -- fixes #5

### DIFF
--- a/styles/method-separator.less
+++ b/styles/method-separator.less
@@ -7,7 +7,6 @@
     width: 100%;
     height: 1px;
     left: 0;
-    top: 0;
     background: @syntax-wrap-guide-color; // wrap guide seems a good choice
     opacity: .5; // set it off from the guide
   }


### PR DESCRIPTION
Removing the top rule seems to fix it. I tested in JS, python and C.

<img width="671" alt="screen shot 2015-11-03 at 11 57 09 am" src="https://cloud.githubusercontent.com/assets/693493/10919887/11416d96-8222-11e5-8d39-071b819c921f.png">

<img width="548" alt="screen shot 2015-11-03 at 11 57 54 am" src="https://cloud.githubusercontent.com/assets/693493/10919900/23af9af2-8222-11e5-9ede-5fed48c95d0d.png">
